### PR TITLE
Potts variables

### DIFF
--- a/rbms/dataset/__init__.py
+++ b/rbms/dataset/__init__.py
@@ -16,7 +16,7 @@ def load_dataset(
     use_weights: bool = False,
     train_size: float = 0.6,
     test_size: Optional[float] = None,
-    binarize: bool = True,
+    binarize: bool = False,
     alphabet="protein",
     seed: int = 19023741073419046239412739401234901,
     device: str = "cpu",

--- a/rbms/dataset/fasta_utils.py
+++ b/rbms/dataset/fasta_utils.py
@@ -6,9 +6,9 @@ import torch
 
 ArrayLike = Tuple[np.ndarray, List]
 
-TOKENS_PROTEIN = "ACDEFGHIKLMNPQRSTVWY-"
-TOKENS_RNA = "ACGU-"
-TOKENS_DNA = "ACGT-"
+TOKENS_PROTEIN = "-ACDEFGHIKLMNPQRSTVWY"
+TOKENS_RNA = "-ACGU"
+TOKENS_DNA = "-ACGT"
 
 
 def get_tokens(alphabet: str):


### PR DESCRIPTION
Unify the default behavior for potts variables related methods, they should all expect categorical variables as an input and output categorical variable.
Same for the dataset loading, the default should be categorical.
Change the ordering of the alphabets for bio data