### PR TITLE
Map model rework

### DIFF
--- a/rbms/io.py
+++ b/rbms/io.py
@@ -65,7 +65,11 @@ def save_model(
 
 
 def load_params(
-    filename: str, index: int, device: torch.device, dtype: torch.dtype
+    filename: str,
+    index: int,
+    device: torch.device,
+    dtype: torch.dtype,
+    map_model: dict[str, RBM] = map_model,
 ) -> RBM:
     """Load the parameters of the RBM from the specified archive at the given update index.
 
@@ -95,6 +99,7 @@ def load_model(
     device: torch.device,
     dtype: torch.dtype,
     restore: bool = False,
+    map_model: dict[str, RBM] = map_model,
 ) -> Tuple[RBM, dict[str, Tensor], float, dict]:
     """Load a RBM from a h5 archive.
 
@@ -126,7 +131,9 @@ def load_model(
             f["hyperparameters"]["learning_rate"][()]
         )
 
-    params = load_params(filename=filename, index=index, device=device, dtype=dtype)
+    params = load_params(
+        filename=filename, index=index, device=device, dtype=dtype, map_model=map_model
+    )
     perm_chains = params.init_chains(visible.shape[0], start_v=visible)
 
     if restore:

--- a/rbms/metrics/aats.py
+++ b/rbms/metrics/aats.py
@@ -25,8 +25,7 @@ def compute_aats(
             AAsyn (float): AATS score for the second sample set.
     """
     # Concatenate data
-    full_data = torch.cat((sample_data[:n_sample], sample_gen[:n_sample]), 1)
-
+    full_data = torch.cat((sample_data[:n_sample], sample_gen[:n_sample]), 0)
     # Compute distance matrix
     match dist:
         case "euclid":

--- a/rbms/parser.py
+++ b/rbms/parser.py
@@ -1,4 +1,7 @@
 import argparse
+from typing import Any
+
+import torch
 
 
 def add_args_pytorch(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
@@ -150,3 +153,16 @@ def remove_argument(parser, arg):
             if (opts and opts[0] == arg) or group_action.dest == arg:
                 action._group_actions.remove(group_action)
                 return
+
+
+def match_args_dtype(args: dict[str, Any]) -> dict[str, Any]:
+    match args["dtype"]:
+        case "int":
+            args["dtype"] = torch.int64
+        case "half":
+            args["dtype"] = torch.float16
+        case "float":
+            args["dtype"] = torch.float32
+        case "double":
+            args["dtype"] = torch.float64
+    return args

--- a/rbms/scripts/pt_sampling.py
+++ b/rbms/scripts/pt_sampling.py
@@ -1,11 +1,13 @@
 import argparse
 
 import h5py
-import torch
 
-from rbms.parser import add_args_pytorch
+from rbms.classes import RBM
+from rbms.io import load_params
+from rbms.map_model import map_model
+from rbms.parser import add_args_pytorch, match_args_dtype
 from rbms.sampling.pt import pt_sampling
-from rbms.utils import check_file_existence, get_saved_updates, load_params
+from rbms.utils import check_file_existence, get_saved_updates
 
 
 def create_parser():
@@ -61,11 +63,14 @@ def run_pt(
     save_index: bool,
     device,
     dtype,
+    map_model: dict[str, RBM] = map_model,
 ):
     check_file_existence(out_file)
 
     age = get_saved_updates(filename)[-1]
-    params = load_params(filename=filename, index=age, device=device, dtype=dtype)
+    params = load_params(
+        filename=filename, index=age, device=device, dtype=dtype, map_model=map_model
+    )
 
     list_chains, inverse_temperatures, index = pt_sampling(
         it_mcmc=it_mcmc,
@@ -88,15 +93,7 @@ def main():
     parser = create_parser()
     args = parser.parse_args()
     args = vars(args)
-    match args["dtype"]:
-        case "int":
-            args["dtype"] = torch.int64
-        case "half":
-            args["dtype"] = torch.float16
-        case "float":
-            args["dtype"] = torch.float32
-        case "double":
-            args["dtype"] = torch.float64
+    args = match_args_dtype(args)
     run_pt(
         filename=args["filename"],
         out_file=args["out_file"],
@@ -107,6 +104,7 @@ def main():
         save_index=args["index"],
         device=args["device"],
         dtype=args["dtype"],
+        map_model=map_model,
     )
 
 

--- a/rbms/scripts/train_rbm.py
+++ b/rbms/scripts/train_rbm.py
@@ -4,6 +4,7 @@ import torch
 
 from rbms.dataset import load_dataset
 from rbms.dataset.parser import add_args_dataset
+from rbms.map_model import map_model
 from rbms.parser import (
     add_args_pytorch,
     add_args_rbm,
@@ -51,6 +52,7 @@ def train_rbm(args: dict):
         args=args,
         dtype=args["dtype"],
         checkpoints=checkpoints,
+        map_model=map_model,
     )
 
 

--- a/rbms/scripts/train_rbm.py
+++ b/rbms/scripts/train_rbm.py
@@ -9,6 +9,7 @@ from rbms.parser import (
     add_args_pytorch,
     add_args_rbm,
     add_args_saves,
+    match_args_dtype,
     remove_argument,
 )
 from rbms.training.pcd import train
@@ -61,15 +62,7 @@ def main():
     parser = create_parser()
     args = parser.parse_args()
     args = vars(args)
-    match args["dtype"]:
-        case "int":
-            args["dtype"] = torch.int64
-        case "half":
-            args["dtype"] = torch.float16
-        case "float":
-            args["dtype"] = torch.float32
-        case "double":
-            args["dtype"] = torch.float64
+    args = match_args_dtype(args)
     train_rbm(args=args)
 
 

--- a/rbms/training/pcd.py
+++ b/rbms/training/pcd.py
@@ -23,6 +23,7 @@ def fit_batch_pcd(
     params: RBM,
     gibbs_steps: int,
     beta: float,
+    centered: bool = True,
 ) -> Tuple[dict[str, Tensor], dict]:
     """Sample the RBM and compute the gradient.
 
@@ -50,7 +51,7 @@ def fit_batch_pcd(
         params=params,
         beta=beta,
     )
-    params.compute_gradient(data=curr_batch, chains=parallel_chains, centered=True)
+    params.compute_gradient(data=curr_batch, chains=parallel_chains, centered=centered)
     logs = {}
     return parallel_chains, logs
 

--- a/rbms/training/pcd.py
+++ b/rbms/training/pcd.py
@@ -63,6 +63,7 @@ def train(
     args: dict,
     dtype: torch.dtype,
     checkpoints: np.ndarray,
+    map_model: dict[str, RBM] = map_model,
 ) -> None:
     """Train the Bernoulli-Bernoulli RBM model.
 

--- a/rbms/training/pcd.py
+++ b/rbms/training/pcd.py
@@ -112,7 +112,7 @@ def train(
         elapsed_time,
         log_filename,
         pbar,
-    ) = setup_training(args)
+    ) = setup_training(args, map_model=map_model)
 
     optimizer = SGD(params.parameters(), lr=learning_rate, maximize=True)
 

--- a/rbms/training/utils.py
+++ b/rbms/training/utils.py
@@ -11,12 +11,14 @@ from tqdm import tqdm
 from rbms.classes import RBM
 from rbms.const import LOG_FILE_HEADER
 from rbms.io import load_model, save_model
+from rbms.map_model import map_model
 from rbms.sampling.gibbs import sample_state
 from rbms.utils import get_saved_updates
 
 
 def setup_training(
     args: dict,
+    map_model: dict[str, RBM] = map_model,
 ) -> Tuple[
     RBM, dict[str, Tensor], dict[str, Any], float, int, float, float, pathlib.Path, tqdm
 ]:
@@ -34,6 +36,7 @@ def setup_training(
         device=args["device"],
         dtype=args["dtype"],
         restore=True,
+        map_model=map_model,
     )
 
     # Hyperparameters
@@ -154,6 +157,8 @@ def get_checkpoints(num_updates: int, n_save: int, spacing: str = "exp") -> np.n
         case "linear":
             checkpoints = np.linspace(1, num_updates, n_save).astype(np.int32)
         case _:
-            raise ValueError(f"spacing should be one of ('exp', 'linear'), got {spacing}")
+            raise ValueError(
+                f"spacing should be one of ('exp', 'linear'), got {spacing}"
+            )
     checkpoints = np.unique(np.append(checkpoints, num_updates))
     return checkpoints

--- a/rbms/utils.py
+++ b/rbms/utils.py
@@ -254,8 +254,12 @@ def swap_chains(
         idx_vis_mean = idx_vis
     idx_hid = idx.unsqueeze(1).repeat(1, chain_1["hidden"].shape[1])
 
-    new_chain_1["visible"] = torch.where(idx_vis, chain_2["visible"], chain_1["visible"])
-    new_chain_2["visible"] = torch.where(idx_vis, chain_1["visible"], chain_2["visible"])
+    new_chain_1["visible"] = torch.where(
+        idx_vis, chain_2["visible"], chain_1["visible"]
+    )
+    new_chain_2["visible"] = torch.where(
+        idx_vis, chain_1["visible"], chain_2["visible"]
+    )
 
     new_chain_1["visible_mag"] = torch.where(
         idx_vis_mean, chain_2["visible_mag"], chain_1["visible_mag"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -147,6 +147,7 @@ def sample_args(tmp_path):
         "num_updates": 3,
         "filename": filename,
         "beta": 1.0,
+        "overwrite": True,
     }
 
 

--- a/tests/unit_test/training/test_pcd.py
+++ b/tests/unit_test/training/test_pcd.py
@@ -4,6 +4,7 @@ import torch
 
 from rbms.bernoulli_bernoulli.classes import BBRBM
 from rbms.io import load_params
+from rbms.map_model import map_model
 from rbms.potts_bernoulli.classes import PBRBM
 from rbms.training.pcd import train
 
@@ -15,7 +16,15 @@ def test_train_bbrbm(sample_dataset_bbrbm, sample_args):
     sample_args["restore"] = False
     sample_args["batch_size"] = pytest.NUM_SAMPLES
     model_type = "BBRBM"
-    train(dataset, test_dataset, model_type, sample_args, torch.float32, checkpoints)
+    train(
+        dataset,
+        test_dataset,
+        model_type,
+        sample_args,
+        torch.float32,
+        checkpoints,
+        map_model=map_model,
+    )
 
     params_begin = load_params(
         sample_args["filename"],
@@ -51,7 +60,15 @@ def test_train_pbrbm(sample_dataset_pbrbm, sample_args):
     sample_args["restore"] = False
     sample_args["batch_size"] = pytest.NUM_SAMPLES
     model_type = "PBRBM"
-    train(dataset, test_dataset, model_type, sample_args, torch.float32, checkpoints)
+    train(
+        dataset,
+        test_dataset,
+        model_type,
+        sample_args,
+        torch.float32,
+        checkpoints,
+        map_model=map_model,
+    )
 
     params_begin = load_params(
         sample_args["filename"],


### PR DESCRIPTION
This pull request changes the way functions interact with the map_model dictionnary. Instead of using the one furnished by the package, they will take it as an input parameter defaulting to the one provided in the package. This should ease a lot integrating new RBM implementation as you would only need to pass the map model as a parameter to use the functions here.