### PR TITLE
Fix load_model

### DIFF
--- a/rbms/io.py
+++ b/rbms/io.py
@@ -125,19 +125,20 @@ def load_model(
         start = np.array(f[last_file_key]["time"]).item()
 
         # Hyperparameters
-        hyperparameters["batch_size"] = int(f["hyperparameters"]["batch_size"][()])
-        hyperparameters["gibbs_steps"] = int(f["hyperparameters"]["gibbs_steps"][()])
-        hyperparameters["learning_rate"] = float(
-            f["hyperparameters"]["learning_rate"][()]
-        )
-        hyperparameters["L1"] = float(f["hyperparameters"]["L1"][()])
-        hyperparameters["L2"] = float(f["hyperparameters"]["L2"][()])
-        if "seed" in f["hyperparameters"].keys():
-            hyperparameters["seed"] = int(f["hyperparameters"]["seed"][()])
-        if "train_size" in f["hyperparameters"].keys():
-            hyperparameters["train_size"] = float(
-                f["hyperparameters"]["train_size"][()]
+        if "hyperparameters" in f.keys():
+            hyperparameters["batch_size"] = int(f["hyperparameters"]["batch_size"][()])
+            hyperparameters["gibbs_steps"] = int(f["hyperparameters"]["gibbs_steps"][()])
+            hyperparameters["learning_rate"] = float(
+                f["hyperparameters"]["learning_rate"][()]
             )
+            hyperparameters["L1"] = float(f["hyperparameters"]["L1"][()])
+            hyperparameters["L2"] = float(f["hyperparameters"]["L2"][()])
+            if "seed" in f["hyperparameters"].keys():
+                hyperparameters["seed"] = int(f["hyperparameters"]["seed"][()])
+            if "train_size" in f["hyperparameters"].keys():
+                hyperparameters["train_size"] = float(
+                    f["hyperparameters"]["train_size"][()]
+                )
     params = load_params(
         filename=filename, index=index, device=device, dtype=dtype, map_model=map_model
     )


### PR DESCRIPTION
#48 
Now I check if the model has a `hyperparameters` key before trying to load them. It should preserve the previous way of using it while making it compatible with `save_model`